### PR TITLE
Regra de atributo para arquivos `.ipynb`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Override jupyter in Github language stats for more accurate estimate of repo code languages
+# reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+# extracted from: https://github.com/openai/whisper/commit/ba88b8e1b38fb6098bfe1e06b09533592e776067
+*.ipynb linguist-generated


### PR DESCRIPTION
Arquivos `.ipynb` são enormes, e as vezes roubam a cena.

Para isso, existe um workaround a fim de evitar que os stats do github incluam arquivos jupyter notebook.